### PR TITLE
Added model voting, delegate staking, and started inflation curve logic

### DIFF
--- a/pallets/model-voting/src/lib copy.rs
+++ b/pallets/model-voting/src/lib copy.rs
@@ -1,0 +1,931 @@
+// Copyright (C) 2021 Subspace Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pallet for issuing rewards to block producers.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+// pub mod weights;
+
+pub use pallet::*;
+use sp_core::OpaquePeerId as PeerId;
+use frame_system::{
+  pallet_prelude::{OriginFor, BlockNumberFor},
+  ensure_signed, ensure_root,
+  WeightInfo,
+  offchain::{
+    AppCrypto, CreateSignedTransaction, SendSignedTransaction, SendUnsignedTransaction,
+    SignedPayload, Signer, SigningTypes, SubmitTransaction,
+  },
+};
+use frame_support::{
+  weights::Weight,
+  pallet_prelude::DispatchResult,
+  ensure,
+  dispatch::Vec,
+  traits::{Currency, LockableCurrency, WithdrawReasons, LockIdentifier},
+};
+use sp_runtime::Percent;
+use sp_runtime::{Saturating, Perbill};
+use sp_core::Get;
+use sp_core::crypto::KeyTypeId;
+use pallet_network::ModelVote;
+
+mod types;
+// mod utils;
+
+pub use types::PropIndex;
+
+const MODEL_VOTING_ID: LockIdentifier = *b"modelvot";
+
+type BalanceOf<T> =
+	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+#[frame_support::pallet]
+pub mod pallet {
+  use super::*;
+  use frame_support::pallet_prelude::*;
+  use sp_runtime::traits::TrailingZeroInput;
+  // use pallet_conviction_voting::pallet as ConvictionVoting;
+
+  #[pallet::config]
+  pub trait Config: frame_system::Config {
+  // pub trait Config: CreateSignedTransaction<Call<Self>> + frame_system::Config {
+    /// `rewards` events
+    type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+    /// The maximum number of public proposals that can exist at any time.
+		#[pallet::constant]
+		type MaxActivateProposals: Get<u32>;
+
+    /// The maximum number of public proposals that can exist at any time.
+		#[pallet::constant]
+		type MaxDeactivateProposals: Get<u32>;
+
+    #[pallet::constant]
+		type MaxProposals: Get<u32>;
+
+    #[pallet::constant]
+		type VotingPeriod: Get<BlockNumberFor<Self>>;
+
+    type ModelVote: ModelVote<Self::AccountId>; 
+
+    type Currency: Currency<Self::AccountId> + LockableCurrency<Self::AccountId, Moment = BlockNumberFor<Self>> + Send + Sync;
+
+    type WeightInfo: WeightInfo;
+  }
+
+  	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+    /// Model path already exists
+		ModelPathExists,
+    /// Model proposal invalid - Can't be (ActivateVoting DectivateVoting Activated)
+		ProposalInvalid,
+    /// Proposal doesn't exist 
+    ProposalNotExist,
+    /// Proposal voting period closed
+    EnactmentPeriodInvalid,
+    /// Proposal voting period closed
+    VotingPeriodInvalid,
+    /// Model ID doens't exist
+    ModelIdNotExists,
+		/// Minimum required model peers not met
+		ModelPeersLengthInvalid,
+    /// Minimum required model peers not met
+		NotEnoughModelInitializationBalance,
+    /// Minimum required model peers stake balance not in wallet
+		NotEnoughMinStakeBalance,
+    /// Not enough balance to vote
+    NotEnoughBalanceToVote,
+    /// Could not convert to balance
+    CouldNotConvertToBalance,
+    /// Proposal type invalid and None
+    PropsTypeInvalid,
+  }
+
+  /// `pallet-rewards` events
+  #[pallet::event]
+  #[pallet::generate_deposit(pub(super) fn deposit_event)]
+  pub enum Event<T: Config> {
+    ModelVoteInInitialized(Vec<u8>, u64),
+    ModelVoteOutInitialized(u32, u64),
+    ModelVoteInSuccess(Vec<u8>, u64),
+    ModelVoteOutSuccess(u32, u64),
+  }
+
+	#[derive(Default, Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+	pub struct ModelPeer<AccountId> {
+    pub account_id: AccountId,
+		pub peer_id: PeerId,
+		pub ip: Vec<u8>,
+		pub port: u16,
+	}
+
+  #[derive(Default, Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+	pub struct ActivatePropsParams<AccountId> {
+    pub path: Vec<u8>,
+		pub model_peers: Vec<ModelPeer<AccountId>>,
+    pub max_block: u64,
+	}
+
+  #[derive(Default, Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+	pub struct PropsParams<AccountId> {
+    pub proposal_status: PropsStatus,
+    pub proposal_type: PropsType,
+    pub path: Vec<u8>,
+		pub model_peers: Vec<ModelPeer<AccountId>>,
+    pub max_block: u64,
+	}
+
+  // #[derive(Default, Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+	// pub struct DeactivatePropsParams<AccountId> {
+  //   pub path: Vec<u8>,
+	// 	pub model_peers: Vec<ModelPeer<AccountId>>,
+	// }
+
+  #[derive(Default, Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+	pub struct VotesParams {
+    pub yay: u128,
+		pub nay: u128,
+	}
+
+  #[derive(Default, Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+	pub struct ActivateVotesParams {
+    pub yay: u128,
+		pub nay: u128,
+	}
+
+  #[pallet::type_value]
+	pub fn DefaultAccountId<T: Config>() -> T::AccountId {
+		T::AccountId::decode(&mut TrailingZeroInput::zeroes()).unwrap()
+	}
+	#[pallet::type_value]
+	pub fn DefaultModelPeer<T: Config>() -> ModelPeer<T::AccountId> {
+		return ModelPeer {
+			account_id: T::AccountId::decode(&mut TrailingZeroInput::zeroes()).unwrap(),
+			peer_id: PeerId(Vec::new()),
+      ip: Vec::new(),
+      port: 0,
+    };
+	}
+	#[pallet::type_value]
+	pub fn DefaultActivatePropsParams<T: Config>() -> ActivatePropsParams<T::AccountId> {
+		return ActivatePropsParams {
+			path: Vec::new(),
+			model_peers: Vec::new(),
+      max_block: 0,
+    };
+	}
+  #[pallet::type_value]
+	pub fn DefaultPropsParams<T: Config>() -> PropsParams<T::AccountId> {
+		return PropsParams {
+      proposal_status: PropsStatus::None,
+      proposal_type: PropsType::None,
+			path: Vec::new(),
+			model_peers: Vec::new(),
+      max_block: 0,
+    };
+	}
+  #[pallet::type_value]
+	pub fn DefaultVotes<T: Config>() -> VotesParams {
+		return VotesParams {
+      yay: 0,
+      nay: 0,
+    }
+	}
+  #[pallet::type_value]
+	pub fn DefaultActivateVotes<T: Config>() -> ActivateVotesParams {
+		return ActivateVotesParams {
+      yay: 0,
+      nay: 0,
+    }
+	}
+  // #[pallet::type_value]
+	// pub fn DefaultDeactivatePropsParams<T: Config>() -> DeactivatePropsParams<T::AccountId> {
+	// 	return DeactivatePropsParams {
+	// 		path: Vec::new(),
+	// 		model_peers: Vec::new(),
+  //   };
+	// }
+  #[pallet::type_value]
+	pub fn DefaultPropsStatus<T: Config>() -> PropsStatus {
+		PropsStatus::None
+	}
+
+  #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+  enum VoteOutReason {
+    // If model peers are performing manipulation for rewards
+    ModelEmissionsManipulation,
+    // If the model is down
+    ModelDown,
+    // If the model isn't open-sourced
+    ModelCloseSourced,
+    // If model is broken
+    ModelBroken,
+    // If the model doesn't have minimum required peers
+    ModelMinimumPeers,
+    // If the model is outputting illicit or illegal data
+    ModelIllicit,
+    // Other
+    Other,
+  }
+
+  #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+  pub enum PropsType {
+    None,
+    Activate,
+    Deactivate,
+  }
+
+  impl Default for PropsType {
+    fn default() -> Self {
+      PropsType::None
+    }
+  }
+
+  #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+  pub enum PropsStatus {
+    // Default status
+    None,
+    // Activation voting
+    ActivateVoting,
+    // Deactivation voting
+    DectivateVoting,
+    // Proposal activated
+    Activated,
+    // Proposal deactivated
+    Deactivated,
+
+    Active,
+
+    Succeeded,
+
+    Defeated,
+  }
+
+  impl Default for PropsStatus {
+    fn default() -> Self {
+      PropsStatus::None
+    }
+  }
+
+	#[pallet::storage]
+	#[pallet::getter(fn activate_props)]
+	pub type ActivateProps<T: Config> =
+		StorageMap<_, Blake2_128Concat, PropIndex, ActivatePropsParams<T::AccountId>, ValueQuery, DefaultActivatePropsParams<T>>;
+
+  #[pallet::storage]
+  #[pallet::getter(fn props)]
+  pub type Proposals<T: Config> =
+    StorageMap<_, Blake2_128Concat, PropIndex, PropsParams<T::AccountId>, ValueQuery, DefaultPropsParams<T>>;
+  
+  #[pallet::storage]
+  #[pallet::getter(fn active_proposals)]
+	pub type ActiveProposals<T> = StorageValue<_, u32, ValueQuery>;
+  
+  #[pallet::storage]
+  #[pallet::getter(fn votes)]
+  pub type Votes<T: Config> =
+    StorageMap<_, Blake2_128Concat, PropIndex, VotesParams, ValueQuery, DefaultVotes<T>>;
+  
+  #[pallet::storage]
+  pub type ActivateVotes<T: Config> =
+    StorageMap<_, Blake2_128Concat, PropIndex, ActivateVotesParams, ValueQuery, DefaultActivateVotes<T>>;
+  
+  #[pallet::storage]
+	#[pallet::getter(fn activate_prop_count)]
+	pub type ActivatePropCount<T> = StorageValue<_, PropIndex, ValueQuery>;
+
+  #[pallet::storage]
+	#[pallet::getter(fn prop_count)]
+	pub type PropCount<T> = StorageValue<_, PropIndex, ValueQuery>;
+
+  #[pallet::storage]
+	#[pallet::getter(fn deactivate_props)]
+	pub type DeactivateProps<T: Config> =
+		StorageMap<_, Blake2_128Concat, PropIndex, ActivatePropsParams<T::AccountId>, ValueQuery, DefaultActivatePropsParams<T>>;
+
+  #[pallet::storage]
+	#[pallet::getter(fn deactivate_prop_count)]
+	pub type DeactivatePropCount<T> = StorageValue<_, PropIndex, ValueQuery>;
+
+  #[pallet::storage]
+	pub type PropsPathStatus<T: Config> =
+		StorageMap<_, Blake2_128Concat, Vec<u8>, PropsStatus, ValueQuery, DefaultPropsStatus<T>>;
+
+  #[pallet::storage]
+  #[pallet::getter(fn quorum)]
+  pub type Quorum<T> = StorageValue<_, u128, ValueQuery>;
+  
+  #[pallet::storage]
+  pub type PeerVotePremium<T> = StorageValue<_, u128, ValueQuery>;
+
+  #[pallet::pallet]
+  #[pallet::without_storage_info]
+  pub struct Pallet<T>(_);
+
+  #[pallet::call]
+  impl<T: Config> Pallet<T> {
+    #[pallet::call_index(0)]
+    #[pallet::weight(0)]
+    pub fn propose(
+      origin: OriginFor<T>, 
+      path: Vec<u8>, 
+      model_peers: Vec<ModelPeer<T::AccountId>>,
+      proposal_type: PropsType
+    ) -> DispatchResult {
+      let account_id: T::AccountId = ensure_signed(origin)?;
+
+      ensure!(
+				proposal_type != PropsType::None,
+				Error::<T>::PropsTypeInvalid
+			);
+
+      if proposal_type == PropsType::Activate {
+        Self::try_propose_activate(account_id.clone(), path.clone(), model_peers.clone());
+      } else if proposal_type == PropsType::Deactivate {
+        ensure!(
+          model_peers.clone().len() == 0,
+          Error::<T>::ModelPeersLengthInvalid
+        );
+        Self::try_propose_deactivate(account_id.clone(), path.clone());
+      }
+
+      let proposal_index = PropCount::<T>::get();
+
+      Proposals::<T>::insert(
+        proposal_index,
+        PropsParams {
+          proposal_status: PropsStatus::Active,
+          proposal_type: proposal_type,
+          path: path.clone(),
+          model_peers: model_peers.clone(),
+          max_block: Self::convert_block_as_u64(<frame_system::Pallet<T>>::block_number() + T::VotingPeriod::get()),
+        },
+      );
+  
+      PropsPathStatus::<T>::insert(path.clone(), PropsStatus::Active);
+
+      PropCount::<T>::put(proposal_index + 1);
+
+      ActiveProposals::<T>::mutate(|n: &mut u32| *n += 1);
+
+      Ok(())
+    }
+
+    #[pallet::call_index(1)]
+    #[pallet::weight(0)]
+    pub fn propose_activate(origin: OriginFor<T>, path: Vec<u8>, model_peers: Vec<ModelPeer<T::AccountId>>) -> DispatchResult {
+			let account_id: T::AccountId = ensure_signed(origin)?;
+
+      // // Check path doesn't already exist in Network or ModelVoting
+      // // If it doesn't already exist, then it has either been not proposed or deactivated
+			// ensure!(
+			// 	!T::ModelVote::get_model_path_exist(path.clone()),
+			// 	Error::<T>::ModelPathExists
+			// );
+
+      // // Ensure can propose new model path
+      // let proposal_status = PropsPathStatus::<T>::get(path.clone());
+
+      // ensure!(
+			// 	proposal_status != PropsStatus::ActivateVoting ||
+      //   proposal_status != PropsStatus::DectivateVoting ||
+      //   proposal_status != PropsStatus::Activated,
+			// 	Error::<T>::ProposalInvalid
+			// );
+
+      // // ...
+
+      // // Ensure account has enough balance to pay cost of model initialization
+      // let model_initialization_cost = T::ModelVote::get_model_initialization_cost();
+      // let model_initialization_cost_as_balance = Self::u128_to_balance(model_initialization_cost);
+
+      // ensure!(
+      //   model_initialization_cost_as_balance.is_some(),
+      //   Error::<T>::CouldNotConvertToBalance
+      // );
+  
+      // let initializer_balance = T::Currency::free_balance(&account_id);
+      // ensure!(
+			// 	model_initialization_cost_as_balance.unwrap() >= initializer_balance,
+			// 	Error::<T>::NotEnoughModelInitializationBalance
+			// );
+
+      // // Lock balance
+      // // The final initialization fee may be more or less than the current initialization cost results
+      // T::Currency::set_lock(
+      //   MODEL_VOTING_ID,
+      //   &account_id,
+      //   model_initialization_cost_as_balance.unwrap(),
+      //   WithdrawReasons::RESERVE
+      // );
+    
+      // // ...
+
+      // // Ensure account is already an existing peer and account eligible
+
+      // // Ensure minimum peers required are already met before going forward
+      // // @to-do: Get minimum model peers from network pallet
+			// ensure!(
+			// 	model_peers.len() as u32 >= T::ModelVote::get_min_model_peers() && 
+      //   model_peers.len() as u32 <= T::ModelVote::get_max_model_peers(),
+			// 	Error::<T>::ModelPeersLengthInvalid
+			// );
+
+      // // Ensure peers have the minimum required stake balance
+      // let min_stake: u128 = T::ModelVote::get_min_stake_balance();
+      // let min_stake_as_balance = Self::u128_to_balance(min_stake);
+
+      // ensure!(
+      //   min_stake_as_balance.is_some(),
+      //   Error::<T>::CouldNotConvertToBalance
+      // );
+
+      // for peer in model_peers.clone() {
+      //   let peer_balance = T::Currency::free_balance(&peer.account_id);
+
+      //   ensure!(
+      //     peer_balance >= min_stake_as_balance.unwrap(),
+      //     Error::<T>::NotEnoughMinStakeBalance
+      //   );
+      // }
+
+      // // Insert proposal
+      // let activate_proposal_index = ActivatePropCount::<T>::get();
+
+      // ActivateProps::<T>::insert(
+      //   activate_proposal_index,
+      //   ActivatePropsParams {
+      //     path: path.clone(),
+      //     model_peers: model_peers.clone(),
+      //     max_block: Self::convert_block_as_u64(<frame_system::Pallet<T>>::block_number() + T::VotingPeriod::get()),
+      //   },
+      // );
+
+      // PropsPathStatus::<T>::insert(path.clone(), PropsStatus::ActivateVoting);
+
+      // ActivatePropCount::<T>::put(activate_proposal_index + 1);
+
+      // ...
+
+      // Vote power based on a time and balance weighted mechanism
+    
+      // ...
+
+      // Queue each model peer to be called in an offchain-worker using their PeerId, IP, and Port to ensure model is running
+      // Must be called multiple times with a 100% success rate over the course of the minimum required voting time span
+
+      // ...
+      Ok(())
+    }
+
+    #[pallet::call_index(2)]
+    #[pallet::weight(0)]
+    pub fn propose_deactivate(
+      origin: OriginFor<T>, 
+      model_id: u32,
+      reason: VoteOutReason,
+      explanation: Vec<u8>,
+    ) -> DispatchResult {
+			// let account_id: T::AccountId = ensure_signed(origin)?;
+
+      // // Ensure path exists in Network
+			// ensure!(
+			// 	T::ModelVote::get_model_id_exist(model_id.clone()),
+			// 	Error::<T>::ModelIdNotExists
+			// );
+
+      // let model_data = T::ModelVote::get_model_data(model_id.clone());
+      // let path = model_data.path;
+
+      // // Ensure can propose new model path
+      // let proposal_status = PropsPathStatus::<T>::get(path.clone());
+
+      // ensure!(
+      //   proposal_status != PropsStatus::ActivateVoting ||
+      //   proposal_status != PropsStatus::DectivateVoting ||
+      //   proposal_status != PropsStatus::Deactivated,
+      //   Error::<T>::ProposalInvalid
+      // );
+      
+      Ok(())
+    }
+
+    #[pallet::call_index(3)]
+    #[pallet::weight(0)]
+    pub fn vote_activation_yes(
+      origin: OriginFor<T>, 
+      proposal_index: PropIndex,
+      vote_amount: BalanceOf<T>,
+    ) -> DispatchResult {
+			// let account_id: T::AccountId = ensure_signed(origin.clone())?;
+
+      // ensure!(
+			// 	ActivateProps::<T>::contains_key(proposal_index.clone()),
+			// 	Error::<T>::ProposalNotExist
+			// );
+
+      // let activation_proposal = ActivateProps::<T>::get(proposal_index.clone());
+      // let path = activation_proposal.path;
+
+      // let proposal_status = PropsPathStatus::<T>::get(path.clone());
+
+      // ensure!(
+      //   proposal_status == PropsStatus::ActivateVoting,
+      //   Error::<T>::ProposalInvalid
+      // );
+
+      // let block = Self::get_current_block_as_u64();
+      // let max_block = activation_proposal.max_block;
+
+      // ensure!(
+			// 	block < max_block,
+			// 	Error::<T>::VotingPeriodInvalid
+			// );
+
+      // let balance = T::Currency::free_balance(&account_id.clone());
+
+      // ensure!(
+			// 	balance >= vote_amount,
+			// 	Error::<T>::NotEnoughBalanceToVote
+			// );
+
+      // let vote_power: u128 = Self::get_voting_power(account_id.clone(), vote_amount);
+
+      // T::Currency::set_lock(
+      //   MODEL_VOTING_ID,
+      //   &account_id,
+      //   vote_amount,
+      //   WithdrawReasons::RESERVE
+      // );
+
+      // ActivateVotes::<T>::mutate(
+      //   proposal_index.clone(),
+      //   |params: &mut ActivateVotesParams| {
+      //     params.yay += vote_power;
+      //   }
+      // );
+
+      Ok(())
+    }
+
+    #[pallet::call_index(4)]
+    #[pallet::weight(0)]
+    pub fn vote_activation_no(
+      origin: OriginFor<T>, 
+      proposal_index: PropIndex,
+      vote_amount: BalanceOf<T>,
+    ) -> DispatchResult {
+			let account_id: T::AccountId = ensure_signed(origin)?;
+      Ok(())
+    }
+
+    #[pallet::call_index(5)]
+    #[pallet::weight(0)]
+    pub fn cast_vote(
+      origin: OriginFor<T>, 
+      proposal_index: PropIndex,
+      vote_amount: BalanceOf<T>,
+    ) -> DispatchResult {
+			let account_id: T::AccountId = ensure_signed(origin)?;
+
+      ensure!(
+        Proposals::<T>::contains_key(proposal_index),
+        Error::<T>::ProposalInvalid
+      );
+  
+      let proposal = Proposals::<T>::get(proposal_index);
+  
+      Self::try_cast_vote(account_id, proposal_index, proposal, vote_amount);
+  
+      Ok(())
+    }
+
+    #[pallet::call_index(6)]
+    #[pallet::weight(0)]
+    pub fn activate_model(
+      origin: OriginFor<T>, 
+      proposal_index: PropIndex,
+    ) -> DispatchResult {
+			let account_id: T::AccountId = ensure_signed(origin)?;
+
+      // Ensure model vote in passed
+
+      Ok(())
+    }
+
+    #[pallet::call_index(7)]
+    #[pallet::weight(0)]
+    pub fn deactivate_model(
+      origin: OriginFor<T>, 
+      proposal_index: PropIndex,
+    ) -> DispatchResult {
+			let account_id: T::AccountId = ensure_signed(origin)?;
+
+      // Ensure model vote out passed
+      Ok(())
+    }
+  }
+
+  #[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+    fn offchain_worker(block_number: BlockNumberFor<T>) {
+    }
+  }
+}
+
+// impl<T: Config + pallet::Config> Pallet<T> {
+impl<T: Config> Pallet<T> {
+  // fn try_propose_activate(account_id: T::AccountId, path: Vec<u8>, model_peers: Vec<ModelPeer<T::AccountId>>) -> DispatchResult {
+  //   // Check path doesn't already exist in Network or ModelVoting
+  //   // If it doesn't already exist, then it has either been not proposed or deactivated
+  //   ensure!(
+  //     !T::ModelVote::get_model_path_exist(path.clone()),
+  //     Error::<T>::ModelPathExists
+  //   );
+
+  //   // Ensure can propose new model path
+  //   let proposal_status = PropsPathStatus::<T>::get(path.clone());
+
+  //   ensure!(
+  //     proposal_status != PropsStatus::ActivateVoting ||
+  //     proposal_status != PropsStatus::Active ||
+  //     proposal_status != PropsStatus::DectivateVoting ||
+  //     proposal_status != PropsStatus::Activated,
+  //     Error::<T>::ProposalInvalid
+  //   );
+
+  //   // // ...
+
+  //   // Ensure account has enough balance to pay cost of model initialization
+  //   let model_initialization_cost = T::ModelVote::get_model_initialization_cost();
+  //   let model_initialization_cost_as_balance = Self::u128_to_balance(model_initialization_cost);
+
+  //   ensure!(
+  //     model_initialization_cost_as_balance.is_some(),
+  //     Error::<T>::CouldNotConvertToBalance
+  //   );
+
+  //   let initializer_balance = T::Currency::free_balance(&account_id);
+  //   ensure!(
+  //     model_initialization_cost_as_balance.unwrap() >= initializer_balance,
+  //     Error::<T>::NotEnoughModelInitializationBalance
+  //   );
+
+  //   // Lock balance
+  //   // The final initialization fee may be more or less than the current initialization cost results
+  //   T::Currency::set_lock(
+  //     MODEL_VOTING_ID,
+  //     &account_id,
+  //     model_initialization_cost_as_balance.unwrap(),
+  //     WithdrawReasons::RESERVE
+  //   );
+  
+  //   // ...
+
+  //   // Ensure account is already an existing peer and account eligible
+
+  //   // Ensure minimum peers required are already met before going forward
+  //   // @to-do: Get minimum model peers from network pallet
+  //   ensure!(
+  //     model_peers.len() as u32 >= T::ModelVote::get_min_model_peers() && 
+  //     model_peers.len() as u32 <= T::ModelVote::get_max_model_peers(),
+  //     Error::<T>::ModelPeersLengthInvalid
+  //   );
+
+  //   // Ensure peers have the minimum required stake balance
+  //   let min_stake: u128 = T::ModelVote::get_min_stake_balance();
+  //   let min_stake_as_balance = Self::u128_to_balance(min_stake);
+
+  //   ensure!(
+  //     min_stake_as_balance.is_some(),
+  //     Error::<T>::CouldNotConvertToBalance
+  //   );
+
+  //   for peer in model_peers.clone() {
+  //     let peer_balance = T::Currency::free_balance(&peer.account_id);
+
+  //     ensure!(
+  //       peer_balance >= min_stake_as_balance.unwrap(),
+  //       Error::<T>::NotEnoughMinStakeBalance
+  //     );
+  //   }
+
+  //   // Insert proposal
+  //   let activate_proposal_index = ActivatePropCount::<T>::get();
+
+
+  //   ActivateProps::<T>::insert(
+  //     activate_proposal_index,
+  //     ActivatePropsParams {
+  //       path: path.clone(),
+  //       model_peers: model_peers.clone(),
+  //       max_block: Self::convert_block_as_u64(<frame_system::Pallet<T>>::block_number() + T::VotingPeriod::get()),
+  //     },
+  //   );
+
+  //   PropsPathStatus::<T>::insert(path.clone(), PropsStatus::ActivateVoting);
+
+  //   ActivatePropCount::<T>::put(activate_proposal_index + 1);
+
+  //   Ok(())
+  // }
+
+  fn try_propose_activate(account_id: T::AccountId, path: Vec<u8>, model_peers: Vec<ModelPeer<T::AccountId>>) -> DispatchResult {
+    // --- Ensure path doesn't already exist in Network or ModelVoting
+    // If it doesn't already exist, then it has either been not proposed or deactivated
+    ensure!(
+      !T::ModelVote::get_model_path_exist(path.clone()),
+      Error::<T>::ModelPathExists
+    );
+
+    // --- Ensure proposal on model path not already in progress
+    let proposal_status = PropsPathStatus::<T>::get(path.clone());
+
+    ensure!(
+      proposal_status != PropsStatus::Active,
+      Error::<T>::ProposalInvalid
+    );
+
+    // --- Ensure account has enough balance to pay cost of model initialization
+    let model_initialization_cost = T::ModelVote::get_model_initialization_cost();
+    let model_initialization_cost_as_balance = Self::u128_to_balance(model_initialization_cost);
+
+    ensure!(
+      model_initialization_cost_as_balance.is_some(),
+      Error::<T>::CouldNotConvertToBalance
+    );
+
+    let initializer_balance = T::Currency::free_balance(&account_id);
+    ensure!(
+      model_initialization_cost_as_balance.unwrap() >= initializer_balance,
+      Error::<T>::NotEnoughModelInitializationBalance
+    );
+
+    // --- Lock balance to be used once succeeded, otherwise it is freed on defeat
+    // The final initialization fee may be more or less than the current initialization cost results
+    T::Currency::set_lock(
+      MODEL_VOTING_ID,
+      &account_id,
+      model_initialization_cost_as_balance.unwrap(),
+      WithdrawReasons::RESERVE
+    );
+  
+    // --- Ensure minimum peers required are already met before going forward
+    // @to-do: Get minimum model peers from network pallet
+    ensure!(
+      model_peers.len() as u32 >= T::ModelVote::get_min_model_peers() && 
+      model_peers.len() as u32 <= T::ModelVote::get_max_model_peers(),
+      Error::<T>::ModelPeersLengthInvalid
+    );
+
+    // --- Ensure peers have the minimum required stake balance
+    let min_stake: u128 = T::ModelVote::get_min_stake_balance();
+    let min_stake_as_balance = Self::u128_to_balance(min_stake);
+
+    ensure!(
+      min_stake_as_balance.is_some(),
+      Error::<T>::CouldNotConvertToBalance
+    );
+
+    for peer in model_peers.clone() {
+      let peer_balance = T::Currency::free_balance(&peer.account_id);
+
+      ensure!(
+        peer_balance >= min_stake_as_balance.unwrap(),
+        Error::<T>::NotEnoughMinStakeBalance
+      );
+    }
+
+    // --- Begin to begin voting
+
+    Ok(())
+  }
+
+  fn try_propose_deactivate(account_id: T::AccountId, path: Vec<u8>) -> DispatchResult {
+    // --- Ensure model ID exists to be removed
+    ensure!(
+      T::ModelVote::get_model_id_by_path(path.clone()) != 0,
+      Error::<T>::ModelIdNotExists
+    );
+
+    // --- Ensure proposal on model path not already in progress
+    let proposal_status = PropsPathStatus::<T>::get(path.clone());
+
+    ensure!(
+      proposal_status != PropsStatus::Active,
+      Error::<T>::ProposalInvalid
+    );
+    
+    Ok(())
+  }
+
+  fn try_cast_vote(
+    account_id: T::AccountId, 
+    proposal_index: PropIndex, 
+    proposal: PropsParams<T::AccountId>,
+    vote_amount: BalanceOf<T>
+  ) -> DispatchResult {
+    let proposal_status = proposal.proposal_status;
+
+    ensure!(
+      proposal_status == PropsStatus::Active,
+      Error::<T>::ProposalInvalid
+    );
+
+    let block = Self::get_current_block_as_u64();
+    let max_block = proposal.max_block;
+
+    ensure!(
+      block < max_block,
+      Error::<T>::VotingPeriodInvalid
+    );
+
+    let balance = T::Currency::free_balance(&account_id.clone());
+
+    ensure!(
+      balance >= vote_amount,
+      Error::<T>::NotEnoughBalanceToVote
+    );
+
+    let vote_power: u128 = Self::get_voting_power(account_id.clone(), vote_amount);
+
+    T::Currency::set_lock(
+      MODEL_VOTING_ID,
+      &account_id,
+      vote_amount,
+      WithdrawReasons::RESERVE
+    );
+
+    Votes::<T>::mutate(
+      proposal_index.clone(),
+      |params: &mut VotesParams| {
+        params.yay += vote_power;
+      }
+    );
+
+    Ok(())
+  }
+
+  fn get_voting_power(account_id: T::AccountId, balance: BalanceOf<T>) -> u128 {
+    // let is_submittable_model_peer_account: bool = T::ModelVote::is_submittable_model_peer_account(account_id);
+
+    // if is_submittable_model_peer_account {
+    //   let peer_vote_premium = Perbill::from_rational(PeerVotePremium::<T>::get(), 100 as u128);
+    //   let voting_power = balance.saturating_add(peer_vote_premium * balance);
+    //   return Self::balance_to_u128(voting_power)
+    // }
+
+    // Self::balance_to_u128(balance)
+    0
+  }
+}
+
+impl<T: Config> Pallet<T> {
+  pub fn u128_to_balance(
+    input: u128,
+  ) -> Option<
+    <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+  > {
+    input.try_into().ok()
+  }
+
+  pub fn balance_to_u128(
+    input: BalanceOf<T>,
+  ) -> u128 {
+    // input.saturated_into::<u128>()
+    // input as u128
+    // input.try_into().ok().expect("REASON")
+
+    return match input.try_into() {
+      Ok(_result) => _result,
+      Err(_error) => 0,
+    }
+  }
+
+  pub fn get_current_block_as_u64() -> u64 {
+    TryInto::try_into(<frame_system::Pallet<T>>::block_number())
+      .ok()
+      .expect("blockchain will not exceed 2^64 blocks; QED.")
+  }
+
+  pub fn convert_block_as_u64(block: BlockNumberFor<T>) -> u64 {
+    TryInto::try_into(block)
+      .ok()
+      .expect("blockchain will not exceed 2^64 blocks; QED.")
+  }
+}

--- a/pallets/network/src/delegate_staking.rs
+++ b/pallets/network/src/delegate_staking.rs
@@ -1,0 +1,325 @@
+// Copyright (C) Hypertensor.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Enables accounts to delegate stake to subnets for a portion of emissions
+
+use super::*;
+
+impl<T: Config> Pallet<T> {
+  pub fn do_add_delegate_stake(
+    origin: T::RuntimeOrigin,
+    model_id: u32,
+    hotkey: T::AccountId,
+    delegate_stake_to_be_added: u128,
+  ) -> DispatchResult {
+    let account_id: T::AccountId = ensure_signed(origin)?;
+
+    let delegate_stake_as_balance = Self::u128_to_balance(delegate_stake_to_be_added);
+
+    ensure!(
+      delegate_stake_as_balance.is_some(),
+      Error::<T>::CouldNotConvertToBalance
+    );
+
+    let account_delegate_stake_shares: u128 = AccountModelDelegateStakeShares::<T>::get(&account_id, model_id.clone());
+    let total_model_delegated_stake_shares = TotalModelDelegateStakeShares::<T>::get(model_id.clone());
+    let total_model_delegated_stake_balance = TotalModelDelegateStakeBalance::<T>::get(model_id.clone());
+
+    // --- Get accounts current balance
+    let account_delegate_stake_balance = Self::convert_to_balance(
+      account_delegate_stake_shares,
+      total_model_delegated_stake_shares,
+      total_model_delegated_stake_balance
+    );
+
+    // ensure!(
+    //   account_delegate_stake_balance != 0,
+    //   Error::<T>::InsufficientBalanceToSharesConversion
+    // );
+
+    ensure!(
+      account_delegate_stake_balance.saturating_add(delegate_stake_to_be_added) <= MaxDelegateStakeBalance::<T>::get(),
+      Error::<T>::MaxDelegatedStakeReached
+    );
+
+    // --- Ensure the callers account_id has enough delegate_stake to perform the transaction.
+    ensure!(
+      Self::can_remove_balance_from_coldkey_account(&account_id, delegate_stake_as_balance.unwrap()),
+      Error::<T>::NotEnoughBalanceToStake
+    );
+  
+    // to-do: add AddStakeRateLimit instead of universal rate limiter
+    //        this allows peers to come in freely
+    let block: u64 = Self::get_current_block_as_u64();
+    ensure!(
+      !Self::exceeds_tx_rate_limit(Self::get_last_tx_block(&account_id), block),
+      Error::<T>::TxRateLimitExceeded
+    );
+
+    // --- Ensure the remove operation from the account_id is a success.
+    ensure!(
+      Self::remove_balance_from_coldkey_account(&account_id, delegate_stake_as_balance.unwrap()) == true,
+      Error::<T>::BalanceWithdrawalError
+    );
+  
+    // --- Get amount to be added as shares based on stake to balance added to account
+    let mut delegate_stake_to_be_added_as_shares = Self::convert_to_shares(
+      delegate_stake_to_be_added,
+      total_model_delegated_stake_shares,
+      total_model_delegated_stake_balance
+    );
+
+    // --- Mitigate inflation attack
+    if total_model_delegated_stake_shares == 0 {
+      TotalModelDelegateStakeShares::<T>::mutate(model_id.clone(), |mut n| *n += 1000);
+      delegate_stake_to_be_added_as_shares = delegate_stake_to_be_added_as_shares.saturating_sub(1000);
+    }
+    
+    // --- Check rounding errors
+    ensure!(
+      delegate_stake_to_be_added_as_shares != 0,
+      Error::<T>::CouldNotConvertToShares
+    );
+
+    Self::increase_account_delegate_stake_shares(
+      &account_id,
+      model_id, 
+      delegate_stake_to_be_added,
+      delegate_stake_to_be_added_as_shares,
+    );
+
+    // Set last block for rate limiting
+    Self::set_last_tx_block(&account_id, block);
+
+    Self::deposit_event(Event::DelegateStakeAdded(model_id, account_id, delegate_stake_to_be_added));
+
+    Ok(())
+  }
+
+  pub fn do_remove_delegate_stake(
+    origin: T::RuntimeOrigin, 
+    model_id: u32,
+    hotkey: T::AccountId,
+    delegate_stake_shares_to_be_removed: u128,
+    // delegate_stake_to_be_removed: u128,
+  ) -> DispatchResult {
+    let account_id: T::AccountId = ensure_signed(origin)?;
+
+    // --- Ensure that the delegate_stake amount to be removed is above zero.
+    ensure!(
+      delegate_stake_shares_to_be_removed > 0,
+      Error::<T>::NotEnoughStakeToWithdraw
+    );
+
+    let account_delegate_stake_shares: u128 = AccountModelDelegateStakeShares::<T>::get(&account_id, model_id.clone());
+
+    log::error!("delegate_stake_shares_to_be_removed {:?}", delegate_stake_shares_to_be_removed);
+    log::error!("account_delegate_stake_shares       {:?}", account_delegate_stake_shares);
+
+    // --- Ensure that the account has enough delegate_stake to withdraw.
+    ensure!(
+      account_delegate_stake_shares >= delegate_stake_shares_to_be_removed,
+      Error::<T>::NotEnoughStakeToWithdraw
+    );
+      
+    let total_model_delegated_stake_shares = TotalModelDelegateStakeShares::<T>::get(model_id.clone());
+    let total_model_delegated_stake_balance = TotalModelDelegateStakeBalance::<T>::get(model_id.clone());
+
+    // --- Get accounts current balance
+    let delegate_stake_to_be_removed = Self::convert_to_balance(
+      account_delegate_stake_shares,
+      total_model_delegated_stake_shares,
+      total_model_delegated_stake_balance
+    );
+
+    // --- Ensure that we can convert this u128 to a balance.
+    let delegate_stake_to_be_added_as_currency = Self::u128_to_balance(delegate_stake_to_be_removed);
+    ensure!(
+      delegate_stake_to_be_added_as_currency.is_some(),
+      Error::<T>::CouldNotConvertToBalance
+    );
+
+    let block: u64 = Self::get_current_block_as_u64();
+    ensure!(
+      !Self::exceeds_tx_rate_limit(Self::get_last_tx_block(&account_id), block),
+      Error::<T>::TxRateLimitExceeded
+    );
+
+    // --- 7. We remove the balance from the hotkey.
+    Self::decrease_account_delegate_stake_shares(&account_id, model_id, delegate_stake_to_be_removed, delegate_stake_shares_to_be_removed);
+
+    let remaining_account_delegate_stake_shares: u128 = AccountModelDelegateStakeShares::<T>::get(&account_id, model_id);
+    
+    // --- 9. We add the balancer to the account_id.  If the above fails we will not credit this account_id.
+    Self::add_balance_to_coldkey_account(&account_id, delegate_stake_to_be_added_as_currency.unwrap());
+    
+    // Set last block for rate limiting
+    Self::set_last_tx_block(&account_id, block);
+
+    Self::deposit_event(Event::DelegateStakeRemoved(model_id, account_id, delegate_stake_to_be_removed));
+
+    Ok(())
+  }
+
+  pub fn increase_account_delegate_stake_shares(
+    account_id: &T::AccountId,
+    model_id: u32, 
+    amount: u128,
+    shares: u128,
+  ) {
+    // -- increase account model staking shares balance
+    AccountModelDelegateStakeShares::<T>::insert(
+      account_id,
+      model_id.clone(),
+      AccountModelDelegateStakeShares::<T>::get(account_id, model_id).saturating_add(shares),
+    );
+
+    // -- increase total model delegate stake balance
+    TotalModelDelegateStakeBalance::<T>::mutate(model_id.clone(), |mut n| *n += amount);
+
+    // -- increase total model delegate stake shares
+    TotalModelDelegateStakeShares::<T>::mutate(model_id.clone(), |mut n| *n += shares);
+  }
+  
+  pub fn decrease_account_delegate_stake_shares(
+    account_id: &T::AccountId,
+    model_id: u32, 
+    amount: u128,
+    shares: u128,
+  ) {
+    // -- decrease account model staking shares balance
+    AccountModelDelegateStakeShares::<T>::insert(
+      account_id,
+      model_id.clone(),
+      AccountModelDelegateStakeShares::<T>::get(account_id, model_id).saturating_sub(shares),
+    );
+
+    // -- increase total model delegate stake balance
+    TotalModelDelegateStakeBalance::<T>::mutate(model_id.clone(), |mut n| *n += amount);
+
+    // -- decrease total model delegate stake shares
+    TotalModelDelegateStakeShares::<T>::mutate(model_id.clone(), |mut n| *n -= shares);
+  }
+
+  // fn can_remove_balance_from_coldkey_account(
+  //   account_id: &T::AccountId,
+  //   amount: <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+  // ) -> bool {
+  //   let current_balance = Self::get_coldkey_balance(account_id);
+  //   if amount > current_balance {
+  //     return false;
+  //   }
+
+  //   // This bit is currently untested. @todo
+  //   let new_potential_balance = current_balance - amount;
+  //   let can_withdraw = T::Currency::ensure_can_withdraw(
+  //     &account_id,
+  //     amount,
+  //     WithdrawReasons::except(WithdrawReasons::TIP),
+  //     new_potential_balance,
+  //   )
+  //   .is_ok();
+  //   can_withdraw
+  // }
+
+  // fn remove_balance_from_coldkey_account(
+  //   account_id: &T::AccountId,
+  //   amount: <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+  // ) -> bool {
+  //   return match T::Currency::withdraw(
+  //     &account_id,
+  //     amount,
+  //     WithdrawReasons::except(WithdrawReasons::TIP),
+  //     ExistenceRequirement::KeepAlive,
+  //   ) {
+  //     Ok(_result) => true,
+  //     Err(_error) => false,
+  //   };
+  // }
+
+  /// Rewards are deposited here
+  pub fn increase_delegated_stake(
+    model_id: u32,
+    amount: u128,
+  ) {
+    // -- increase total model delegate stake 
+    TotalModelDelegateStakeBalance::<T>::mutate(model_id.clone(), |mut n| *n += amount);
+  }
+
+  // pub fn add_balance_to_coldkey_account(
+  //   account_id: &T::AccountId,
+  //   amount: <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+  // ) {
+  //   T::Currency::deposit_creating(&account_id, amount); // Infallibe
+  // }
+
+  // pub fn get_coldkey_balance(
+  //   account_id: &T::AccountId,
+  // ) -> <<T as pallet::Config>::Currency as Currency<<T as system::Config>::AccountId>>::Balance {
+  //   return T::Currency::free_balance(&account_id);
+  // }
+
+  // pub fn u128_to_balance(
+  //   input: u128,
+  // ) -> Option<
+  //   <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+  // > {
+  //   input.try_into().ok()
+  // }
+
+  pub fn get_delegate_stake_balance(
+    model_id: u32,
+    account_id: &T::AccountId,
+  ) -> u128 {
+    0
+  }
+
+  pub fn get_delegate_shares_balance(
+    model_id: u32,
+    account_id: &T::AccountId,
+  ) -> u128 {
+    0
+  }
+
+  pub fn convert_to_balance(
+    shares: u128,
+    total_shares: u128,
+    total_balance: u128
+  ) -> u128 {
+    log::error!("convert_to_balance shares        {:?}", shares);
+    log::error!("convert_to_balance total_shares  {:?}", total_shares);
+    log::error!("convert_to_balance total_balance {:?}", total_balance);
+    if total_shares == 0 {
+      return shares;
+    }
+    // shares.saturating_mul(total_balance).saturating_div(total_shares)
+    shares.saturating_mul(total_balance.saturating_div(total_shares))
+  }
+
+  pub fn convert_to_shares(
+    balance: u128,
+    total_shares: u128,
+    total_balance: u128
+  ) -> u128 {
+    log::error!("convert_to_shares balance        {:?}", balance);
+    log::error!("convert_to_shares total_shares   {:?}", total_shares);
+    log::error!("convert_to_shares total_balance  {:?}", total_balance);
+    if total_shares == 0 {
+      return balance;
+    }
+    // balance.saturating_mul(total_shares).saturating_div(total_balance)
+    balance.saturating_mul(total_shares.saturating_div(total_balance))
+  }
+}

--- a/pallets/network/src/emission.rs
+++ b/pallets/network/src/emission.rs
@@ -18,7 +18,6 @@ use system::Config;
 use frame_support::dispatch::Vec;
 use num_traits::float::FloatCore;
 use sp_runtime::{PerThing, Percent};
-// use sp_arithmetic::{Percent, PerThing};
 use sp_runtime::Saturating;
 
 impl<T: Config + pallet::Config> Pallet<T> {

--- a/pallets/network/src/inflation_curve.rs
+++ b/pallets/network/src/inflation_curve.rs
@@ -1,0 +1,114 @@
+use super::*;
+use crate::{
+  MILLISECS_PER_BLOCK,
+  DAYS,
+  YEAR
+};
+use frame_support::dispatch::Vec;
+
+impl<T: Config> Pallet<T> {
+  pub fn get_opt_models() -> u32 {
+    OptimalModels::<T>::get()
+  }
+
+  pub fn get_opt_models_percent() -> u128 {
+    let opt_models = Self::get_opt_models();
+    // Self::percent_div(opt_models as u128, MaxModels::<T>::get() as u128)
+    Self::PERCENTAGE_FACTOR
+  }
+
+  pub fn get_opt_peers() -> u32 {
+    // MAX: 4_294_967_295u32
+    let opt_peers_per_model = OptimalPeersPerModel::<T>::get();
+    let total_models = TotalModels::<T>::get();
+    opt_peers_per_model * total_models
+  }
+
+  pub fn get_opt_peers_percent() -> u128 {
+    let max_models = MaxModels::<T>::get();
+    let max_models = MaxModelPeers::<T>::get();
+    let opt_peers = Self::get_opt_peers();
+    Self::percent_div(opt_peers as u128, (max_models * max_models) as u128)
+  }
+
+  pub fn get_slope() -> u128 {
+    400
+  }
+
+  pub fn get_opt_apr(total_stake_balance: u128) -> u128 {
+    9
+  }
+
+  pub fn get_apr() -> u128 {
+
+  }
+
+  pub fn get_lower_bound(usage: u128) -> u128 {
+    let total_models = TotalModels::<T>::get();
+    let main_lower_bound = InflationLowerBound::<T>::get();
+    let epoch_lower_bound = Self::percent_mul(main_lower_bound, usage);
+    epoch_lower_bound
+  }
+
+  pub fn get_upper_bound(usage: u128) -> u128 {
+    let total_models = TotalModels::<T>::get();
+    let main_upper_bound = InflationUpperBound::<T>::get();
+    let epoch_upper_bound = Self::PERCENTAGE_FACTOR - (Self::PERCENTAGE_FACTOR - main_upper_bound) * usage;
+    epoch_upper_bound
+  }
+
+  // Get decay of emissions as a variable
+  pub fn get_decay(total_models: u32, block: u64, interval: u64) -> u128 {
+    let opt_models = Self::get_opt_models();
+    let max_models = MaxModels::<T>::get();
+    let total_models = TotalModels::<T>::get();
+    let usage = Self::percent_div(total_models as u128, max_models as u128);
+
+    // --- Get upper bound
+    let total_models = TotalModels::<T>::get();
+    let main_upper_bound = InflationUpperBound::<T>::get();
+    let epoch_upper_bound = Self::PERCENTAGE_FACTOR - (Self::PERCENTAGE_FACTOR - main_upper_bound) * usage;
+
+    // -- Get lower bound
+    let total_models = TotalModels::<T>::get();
+    let main_lower_bound = InflationLowerBound::<T>::get();
+    let epoch_lower_bound = Self::percent_mul(main_lower_bound, usage);
+
+    // -- Get delta
+    let bound_delta = epoch_upper_bound - epoch_lower_bound;
+
+    // -- Get time decay
+    let time_decay = TimeDecay::<T>::get();
+
+    // -- Get last block model initialized
+    let last_block_model_initialized = LastModelInitializationBlock::<T>::get();
+
+    // -- Get end of time period
+    let end_of_time_decay = last_block_model_initialized + time_decay;
+
+    let mut time_elapsed_as_percentage = Self::PERCENTAGE_FACTOR;
+
+    // --- Block should always be greater than the last_block_model_initialized
+
+    // --- Get percentage of time elapsed since the last model was initialized in 
+    //     relation to the time decay between models initialization
+    if block < end_of_time_decay {
+      let time_elasped = block - last_block_model_initialized;
+      time_elapsed_as_percentage = Self::percent_div(time_elasped, time_decay)
+    }
+
+    time_elapsed_as_percentage * bound_delta / Self::PERCENTAGE_FACTOR + epoch_lower_bound
+  }
+
+  pub fn get_epochs_emissions(peers_count: u32, total_stake_balance: u128) -> u128 {
+    // --- Get APR
+    let apr = Self::get_apr();
+
+    // --- Calculate APR as an epoch to get total emissions
+    let milliseconds_per_block: u64 = MILLISECS_PER_BLOCK;
+    let consensus_blocks_interval: u64 = ConsensusBlocksInterval::<T>::get();
+    let x = consensus_blocks_interval / YEAR;
+    9
+  }
+
+}

--- a/pallets/network/src/info.rs
+++ b/pallets/network/src/info.rs
@@ -105,10 +105,4 @@ impl<T: Config> Pallet<T> {
 
     unconfirmed_count
   }
-
-  // pub fn get_model_peers(
-  //   model_id: u32,
-  // ) -> Vec<u8> {
-  //   "ls-team/StableBeluga2".into()
-  // }
 }

--- a/pallets/network/src/math.rs
+++ b/pallets/network/src/math.rs
@@ -12,6 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+//
+//
+//
+// @to-do: Increase precision to 100.0000
 
 use super::*;
 

--- a/pallets/network/src/staking.rs
+++ b/pallets/network/src/staking.rs
@@ -89,7 +89,7 @@ impl<T: Config> Pallet<T> {
     // --- Ensure that the stake amount to be removed is above zero.
     ensure!(
       stake_to_be_removed > 0,
-      Error::<T>::NotEnoughStaketoWithdraw
+      Error::<T>::NotEnoughStakeToWithdraw
     );
 
     let account_stake_balance: u128 = AccountModelStake::<T>::get(&account_id, model_id.clone());
@@ -97,7 +97,7 @@ impl<T: Config> Pallet<T> {
     // --- Ensure that the account has enough stake to withdraw.
     ensure!(
       account_stake_balance >= stake_to_be_removed,
-      Error::<T>::NotEnoughStaketoWithdraw
+      Error::<T>::NotEnoughStakeToWithdraw
     );
     
     // if user is still a peer in consensus they must keep the required minimum balance
@@ -252,5 +252,4 @@ impl<T: Config> Pallet<T> {
   > {
     input.try_into().ok()
   }
-
 }

--- a/pallets/network/src/utils.rs
+++ b/pallets/network/src/utils.rs
@@ -53,7 +53,7 @@ impl<T: Config> Pallet<T> {
       .expect("blockchain will not exceed 2^64 blocks; QED.")
   }
 
-  pub fn convert_current_block_as_u64(block: BlockNumberFor<T>) -> u64 {
+  pub fn convert_block_as_u64(block: BlockNumberFor<T>) -> u64 {
     TryInto::try_into(block)
       .ok()
       .expect("blockchain will not exceed 2^64 blocks; QED.")
@@ -489,4 +489,30 @@ impl<T: Config> Pallet<T> {
 
     total_submit_eligible_model_peers
   }
+
+  pub fn get_total_dishonesty_voting_model_peers(
+    model_id: u32,
+    block: u64,
+    consensus_blocks_interval: u64,
+    min_required_peer_consensus_dishonesty_epochs: u64
+  ) -> u32 {
+    // Count of eligible to submit consensus data model peers
+    let mut total_submit_eligible_model_peers = 0;
+    
+    // increment total_submit_eligible_model_peers with model peers that are eligible to submit consensus data
+    for model_peer in ModelPeersData::<T>::iter_prefix_values(model_id.clone()) {
+      let initialized: u64 = model_peer.initialized;
+      if Self::is_epoch_block_eligible(
+        block, 
+        consensus_blocks_interval, 
+        min_required_peer_consensus_dishonesty_epochs, 
+        initialized
+      ) {
+        total_submit_eligible_model_peers += 1;
+      }
+    }
+
+    total_submit_eligible_model_peers
+  }
+
 }


### PR DESCRIPTION
New models can be proposed to be voted in, current models can be proposed to be voted out. This allows accounts to vote for proposals using yay/nay/abstain by locking their funds. Current peers have higher voting power.

Delegate staking allows accounts to stake towards subnets to get rewards. This only has logic for staking similar to ERC4626 but the logic to add the token to the balance needs to be added in the emissions logic.

Inflation curve logic started here but not included, imported, in the network pallet yet.